### PR TITLE
#4 Fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,11 @@ repos:
     rev: v2.20.0
     hooks:
     -   id: validate_manifest
+-   repo: local
+    hooks:
+    -   id: stylua
+        name: stylua
+        description: Format files with StyLua.
+        entry: stylua .
+        language: system
+        types: [lua]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,0 @@
-- id: fmt
-  name: fmt
-  description: Format files with StyLua.
-  entry: stylua
-  language: system
-  types: [lua]


### PR DESCRIPTION
### Changes
- Pre-commit config is sufficient for local custom hooks. Add custom hook to `.pre-commit-config.yaml` and remove the `.pre-commit-hooks.yaml` file.

### Issues
- Closes #4 
